### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/achitek-org/achitek/compare/v0.1.0...v0.1.1)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Upgrade git2 to version 0.20.4  - ([d516f12](https://github.com/achitek-org/achitek/commit/d516f1245514f9d7eb975ffde456f34528c7474d))
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "achitek"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achitekfile",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "achitek"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.90.0"
 description = "achitek cli"


### PR DESCRIPTION



## 🤖 New release

* `achitek`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/achitek-org/achitek/compare/v0.1.0...v0.1.1)

### ⚙️ Miscellaneous Tasks


- Upgrade git2 to version 0.20.4  - ([d516f12](https://github.com/achitek-org/achitek/commit/d516f1245514f9d7eb975ffde456f34528c7474d))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).